### PR TITLE
修正：複数行の文字列

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,7 +21,7 @@ jobs:
         id: diff
         run: |
           diff=$(git diff)
-          test -n $diff && change="found" || change="none"
+          test -n "$diff" && change="found" || change="none"
           echo "::set-output name=change::$change"
       - name: debug
         if: steps.diff.outputs.change == 'found'


### PR DESCRIPTION
bashだとクオテーションで囲って引数に渡す必要あり